### PR TITLE
feat: 選択した言語同士を画面に表示、繁体字と簡体字を別途扱えるようにする.履歴も見れるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,59 +6,137 @@ A new Flutter project.
 
 This project is a starting point for a Flutter application.
 
-# Today's Sentence - 語学学習アプリ
+# Today's Sentence - Language Learning App
 
-多言語対応の語学学習アプリです。毎日異なる短文を表示し、単語の意味や翻訳を学習できます。
+A multilingual language learning application built with Flutter that displays daily sentences with translations, word definitions, and audio pronunciation support.
 
-## 機能
+## Features
 
-- **多言語サポート**: 日本語、英語、中国語、ドイツ語、スウェーデン語
-- **興味別カテゴリ**: 20の興味分野から選択可能
-  - Technology (テクノロジー)
-  - Science (サイエンス)  
-  - Health (健康)
-  - Travel (旅行)
-  - Business (ビジネス)
-  - Sports (スポーツ)
-  - Music (音楽)
-  - Movies (映画)
-  - Books (本)
-  - Nature (自然)
-  - History (歴史)
-  - Art (アート)
-  - Education (教育)
-  - Philosophy (哲学)
-  - Psychology (心理学)
-  - Economics (経済)
-  - Politics (政治)
-  - Environment (環境)
-  - Culture (文化)
-  - Food (料理)
+### 🌍 Multi-language Support
+- **Learning Languages**: English, Japanese, Chinese (Simplified & Traditional), German, Swedish
+- **Native Language Settings**: Separate configuration for translation display
+- **Chinese Conversion**: Automatic conversion between Traditional and Simplified Chinese
 
-- **詳細表示機能**:
-  - 母国語への翻訳
-  - 単語辞書（発音、意味、例文）
-  - Show Detailsボタンで詳細の表示/非表示
+### 📚 Content Categories
+Choose from 20 different interest categories:
+- Technology, Science, Health, Travel, Business
+- Sports, Music, Movies, Books, Nature
+- History, Art, Education, Philosophy, Psychology
+- Economics, Politics, Environment, Culture, Food
 
-- **毎日の通知**: 毎日10時（カスタマイズ可能）に新しい文章をお知らせ
+### 🔧 Core Features
+- **Daily Sentences**: New sentence every day based on selected languages and categories
+- **Smart Translations**: Translations displayed in your native language
+- **Word Dictionary**: Detailed word definitions with pronunciation and examples
+- **Text-to-Speech**: Audio pronunciation for all supported languages
+- **Learning History**: Track your learning progress over time
+- **Push Notifications**: Daily reminders at customizable times
+- **Chinese Variants**: Support for both Simplified and Traditional Chinese with conversion
 
-## 使い方
+### 🎨 User Interface
+- Clean, intuitive Material Design interface
+- Show/hide translation and word details
+- Responsive layout for all screen sizes
+- Dark/light mode support
 
-1. **言語選択**: 学習したい言語を選択
-2. **興味分野選択**: 学びたいトピックを複数選択
-3. **毎日の学習**: 表示された文章を読む
-4. **詳細学習**: "Show Details"ボタンを押して翻訳や単語の詳細を確認
-5. **通知設定**: 好きな時間に通知を設定
+## Screenshots
 
-## 技術仕様
+| Home Screen | Settings | History |
+|------------|----------|---------|
+| Daily sentence display with audio | Language and category selection | Learning progress tracking |
 
-- **フレームワーク**: Flutter 3.x
-- **状態管理**: Provider パターン
-- **ローカルストレージ**: SharedPreferences
-- **通知**: flutter_local_notifications
-- **権限管理**: permission_handler
+## Quick Start
 
-## 依存関係
+### Prerequisites
+- Flutter SDK 3.0 or higher
+- Dart SDK 3.0 or higher
+- Android Studio / VS Code with Flutter plugins
+- Git
+
+### Installation
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/orug8m/todays_sentence.git
+   cd todays_sentence
+   ```
+
+2. **Install dependencies**
+   ```bash
+   flutter pub get
+   ```
+
+3. **Generate code (JSON serialization)**
+   ```bash
+   dart run build_runner build
+   ```
+
+4. **Run the app**
+   ```bash
+   # For web (recommended for development)
+   flutter run -d chrome
+   
+   # For mobile (requires device/emulator)
+   flutter run -d android
+   flutter run -d ios
+   ```
+
+### Platform-specific Setup
+
+#### Android
+- Minimum SDK: 21 (Android 5.0)
+- Permissions: Notifications, Audio
+
+#### iOS
+- Minimum deployment target: iOS 12.0
+- Permissions: Notifications, Audio
+
+#### Web
+- Supports all modern browsers
+- Some features (notifications, TTS) may have limited functionality
+
+## Configuration
+
+### Language Settings
+1. Open the app and navigate to Settings
+2. Set your **Native Language** (for translations)
+3. Choose your **Learning Language** (for sentences)
+4. Select **Interest Categories** (multiple selection allowed)
+
+### Notifications
+- Default: Daily at 10:00 AM
+- Customizable through Settings screen
+- Requires notification permissions
+
+## Architecture
+
+### Project Structure
+```
+lib/
+├── models/           # Data models (Language, Sentence, etc.)
+├── services/         # Business logic services
+│   ├── sentence_service.dart
+│   ├── settings_service.dart
+│   ├── tts_service.dart
+│   ├── history_service.dart
+│   └── chinese_translation_service.dart
+├── providers/        # State management (Provider pattern)
+├── screens/          # UI screens
+│   ├── home_screen.dart
+│   ├── settings_screen.dart
+│   └── history_screen.dart
+└── main.dart
+```
+
+### Key Technologies
+- **Flutter 3.x**: Cross-platform UI framework
+- **Provider**: State management pattern
+- **SharedPreferences**: Local data persistence
+- **flutter_local_notifications**: Push notifications
+- **flutter_tts**: Text-to-speech functionality
+- **JSON serialization**: Data model serialization
+
+## Dependencies
 
 ```yaml
 dependencies:
@@ -66,62 +144,131 @@ dependencies:
     sdk: flutter
   provider: ^6.1.2
   shared_preferences: ^2.2.2
-  http: ^1.2.0
   flutter_local_notifications: ^17.0.0
+  flutter_tts: ^3.8.3
   permission_handler: ^11.3.1
   json_annotation: ^4.8.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  build_runner: ^2.4.9
+  json_serializable: ^6.7.1
+  flutter_lints: ^3.0.0
 ```
 
-## セットアップ
+## Development
 
-1. リポジトリをクローン
+### Running Tests
 ```bash
-git clone <repository-url>
-cd todays_sentence
+flutter test
 ```
 
-2. 依存関係をインストール
+### Building for Production
+
+#### Web
 ```bash
+flutter build web
+```
+
+#### Android APK
+```bash
+flutter build apk --release
+```
+
+#### iOS
+```bash
+flutter build ios --release
+```
+
+### Adding New Languages
+
+1. Update the `Language` enum in `lib/models/language.dart`
+2. Add sentence data to `_sentenceDatabase` in `lib/services/sentence_service.dart`
+3. Add translation mappings in `_getBasicTranslation` method
+4. Update TTS language codes in `lib/services/tts_service.dart`
+
+### Adding New Categories
+
+1. Update `InterestCategory` enum in `lib/models/interest_category.dart`
+2. Add corresponding sentence data for all supported languages
+3. Update UI strings and icons as needed
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+### Contribution Guidelines
+- Follow Flutter/Dart style guide
+- Add tests for new features
+- Update documentation
+- Ensure all languages have equivalent content
+
+## Troubleshooting
+
+### Common Issues
+
+**Build errors after cloning**
+```bash
+flutter clean
 flutter pub get
+dart run build_runner build --delete-conflicting-outputs
 ```
 
-3. JSONシリアライゼーションコードを生成
-```bash
-dart run build_runner build
-```
+**Notification not working**
+- Check device notification permissions
+- Verify notification time settings
+- Test on physical device (notifications may not work in simulators)
 
-4. アプリを実行
-```bash
-flutter run
-```
+**TTS not working**
+- Verify device has TTS engine installed
+- Check audio permissions
+- Test with different languages
 
-## 文章データについて
+**Web platform limitations**
+- TTS functionality is limited on web
+- Notifications require user interaction
+- Some mobile-specific features unavailable
 
-現在は事前定義された文章データベースを使用しています。将来的には以下のような外部APIとの連携を検討しています：
+## Roadmap
 
-- ニュースAPI（多言語対応）
-- 教育コンテンツAPI
-- 辞書API
+### Upcoming Features
+- [ ] Cloud synchronization for settings and history
+- [ ] Offline mode with cached content
+- [ ] Learning statistics and progress tracking
+- [ ] Spaced repetition algorithm
+- [ ] Community features and sentence sharing
+- [ ] Integration with external language APIs
+- [ ] Widget support for home screen
+- [ ] Apple Watch / Android Wear support
 
-## プラットフォーム対応
+### Long-term Goals
+- [ ] AI-powered personalized content
+- [ ] Voice recognition for pronunciation practice
+- [ ] Gamification elements
+- [ ] Social learning features
+- [ ] Premium subscription model
 
-- ✅ Android
-- ✅ iOS
-- ✅ Web（制限付き）
+## License
 
-## ライセンス
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-MIT License
+## Acknowledgments
 
-## 貢献
+- Flutter team for the amazing framework
+- Community contributors for language content
+- Open source libraries that made this project possible
 
-プルリクエストやイシューの報告を歓迎します。
+## Support
 
-## 今後の予定
+- 📧 Email: [your-email@example.com]
+- 🐛 Issues: [GitHub Issues](https://github.com/orug8m/todays_sentence/issues)
+- 💬 Discussions: [GitHub Discussions](https://github.com/orug8m/todays_sentence/discussions)
 
-- [ ] より多くの言語サポート
-- [ ] 学習履歴機能
-- [ ] 音声読み上げ機能
-- [ ] 外部API連携
-- [ ] ユーザー設定のクラウド同期
-- [ ] 学習統計とプログレス表示
+---
+
+**Happy Learning! 📚✨**

--- a/lib/models/language.dart
+++ b/lib/models/language.dart
@@ -13,9 +13,9 @@ enum Language {
   final String code;
 
   String get displayName => nativeName;
-  
+
   bool get isChinese => this == chineseSimplified || this == chineseTraditional;
-  
+
   Language get chineseCounterpart {
     if (this == chineseSimplified) return chineseTraditional;
     if (this == chineseTraditional) return chineseSimplified;

--- a/lib/providers/app_provider_fixed.dart
+++ b/lib/providers/app_provider_fixed.dart
@@ -5,8 +5,8 @@ import '../models/sentence.dart';
 import '../services/settings_service.dart';
 import '../services/sentence_service.dart';
 import '../services/notification_service.dart';
+import '../services/database_service.dart';
 import '../services/tts_service.dart';
-import '../services/history_service.dart';
 
 class AppProvider with ChangeNotifier {
   final SettingsService _settingsService = SettingsService();
@@ -75,7 +75,6 @@ class AppProvider with ChangeNotifier {
   Future<void> setNativeLanguage(Language language) async {
     _nativeLanguage = language;
     await _settingsService.saveNativeLanguage(language);
-    await loadTodaysSentence(); // 翻訳を更新するため文章を再読み込み
     notifyListeners();
   }
 
@@ -107,12 +106,11 @@ class AppProvider with ChangeNotifier {
       _todaysSentence = await _sentenceService.getTodaysSentence(
         _selectedLanguage,
         _selectedCategories,
-        _nativeLanguage, // Native languageを渡す
       );
 
       // Save to history when loaded
       if (_todaysSentence != null) {
-        await HistoryService.saveSentenceToHistory(_todaysSentence!);
+        await DatabaseService.saveSentenceToHistory(_todaysSentence!);
         await loadSentenceHistory(); // Refresh history
       }
     } catch (e) {
@@ -135,7 +133,7 @@ class AppProvider with ChangeNotifier {
 
   Future<void> loadSentenceHistory() async {
     try {
-      _sentenceHistory = await HistoryService.getHistory();
+      _sentenceHistory = await DatabaseService.getHistory();
     } catch (e) {
       if (kDebugMode) {
         print('Error loading sentence history: $e');
@@ -152,11 +150,10 @@ class AppProvider with ChangeNotifier {
       _todaysSentence = await _sentenceService.getRandomSentence(
         _selectedLanguage,
         _selectedCategories,
-        _nativeLanguage, // Native languageを渡す
       );
 
       if (_todaysSentence != null) {
-        await HistoryService.saveSentenceToHistory(_todaysSentence!);
+        await DatabaseService.saveSentenceToHistory(_todaysSentence!);
         await loadSentenceHistory();
       }
     } catch (e) {
@@ -191,7 +188,7 @@ class AppProvider with ChangeNotifier {
   }
 
   Future<void> clearHistory() async {
-    await HistoryService.clearHistory();
+    await DatabaseService.clearHistory();
     _sentenceHistory = [];
     notifyListeners();
   }

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -70,7 +70,8 @@ class HistoryScreen extends StatelessWidget {
       builder: (BuildContext context) {
         return AlertDialog(
           title: const Text('Clear History'),
-          content: const Text('Are you sure you want to clear all learning history?'),
+          content: const Text(
+              'Are you sure you want to clear all learning history?'),
           actions: [
             TextButton(
               onPressed: () {
@@ -164,7 +165,8 @@ class HistoryScreen extends StatelessWidget {
                   const Divider(),
                   Row(
                     children: [
-                      Icon(Icons.translate, color: Colors.green.shade600, size: 20),
+                      Icon(Icons.translate,
+                          color: Colors.green.shade600, size: 20),
                       const SizedBox(width: 8),
                       Text(
                         'Translation',
@@ -203,48 +205,51 @@ class HistoryScreen extends StatelessWidget {
                   Expanded(
                     child: ListView(
                       controller: scrollController,
-                      children: sentence.words.map((word) => Padding(
-                        padding: const EdgeInsets.only(bottom: 12),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              children: [
-                                Text(
-                                  word.word,
-                                  style: const TextStyle(
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                                if (word.pronunciation != null) ...[
-                                  const SizedBox(width: 8),
-                                  Text(
-                                    word.pronunciation!,
-                                    style: TextStyle(
-                                      fontSize: 14,
-                                      color: Colors.grey.shade600,
-                                      fontStyle: FontStyle.italic,
+                      children: sentence.words
+                          .map((word) => Padding(
+                                padding: const EdgeInsets.only(bottom: 12),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Row(
+                                      children: [
+                                        Text(
+                                          word.word,
+                                          style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                        if (word.pronunciation != null) ...[
+                                          const SizedBox(width: 8),
+                                          Text(
+                                            word.pronunciation!,
+                                            style: TextStyle(
+                                              fontSize: 14,
+                                              color: Colors.grey.shade600,
+                                              fontStyle: FontStyle.italic,
+                                            ),
+                                          ),
+                                        ],
+                                      ],
                                     ),
-                                  ),
-                                ],
-                              ],
-                            ),
-                            const SizedBox(height: 4),
-                            Text(word.definition, style: const TextStyle(fontSize: 14)),
-                            if (word.examples.isNotEmpty) ...[
-                              const SizedBox(height: 4),
-                              Text(
-                                'Examples: ${word.examples.join(', ')}',
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color: Colors.grey.shade600,
+                                    const SizedBox(height: 4),
+                                    Text(word.definition,
+                                        style: const TextStyle(fontSize: 14)),
+                                    if (word.examples.isNotEmpty) ...[
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        'Examples: ${word.examples.join(', ')}',
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          color: Colors.grey.shade600,
+                                        ),
+                                      ),
+                                    ],
+                                  ],
                                 ),
-                              ),
-                            ],
-                          ],
-                        ),
-                      )).toList(),
+                              ))
+                          .toList(),
                     ),
                   ),
                 ],
@@ -283,7 +288,8 @@ class HistoryCard extends StatelessWidget {
               Row(
                 children: [
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: Colors.blue.shade100,
                       borderRadius: BorderRadius.circular(12),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -152,12 +152,16 @@ class _SentenceCardState extends State<SentenceCard> {
                             onPressed: () {
                               provider.speakSentence(widget.sentence.text);
                             },
-                            icon: Icon(provider.isSpeaking ? Icons.stop : Icons.volume_up),
-                            label: Text(provider.isSpeaking ? 'Stop' : 'Listen'),
+                            icon: Icon(provider.isSpeaking
+                                ? Icons.stop
+                                : Icons.volume_up),
+                            label:
+                                Text(provider.isSpeaking ? 'Stop' : 'Listen'),
                             style: ElevatedButton.styleFrom(
                               backgroundColor: Colors.green.shade600,
                               foregroundColor: Colors.white,
-                              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8),
                             ),
                           );
                         },
@@ -172,12 +176,15 @@ class _SentenceCardState extends State<SentenceCard> {
                           _showDetails = !_showDetails;
                         });
                       },
-                      icon: Icon(_showDetails ? Icons.expand_less : Icons.expand_more),
-                      label: Text(_showDetails ? 'Hide Details' : 'Show Details'),
+                      icon: Icon(
+                          _showDetails ? Icons.expand_less : Icons.expand_more),
+                      label:
+                          Text(_showDetails ? 'Hide Details' : 'Show Details'),
                       style: ElevatedButton.styleFrom(
                         backgroundColor: Colors.blue.shade600,
                         foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 24, vertical: 12),
                       ),
                     ),
                   ),
@@ -250,9 +257,10 @@ class _SentenceCardState extends State<SentenceCard> {
                         ],
                       ),
                       const SizedBox(height: 12),
-                      ...widget.sentence.words.map((word) => WordDefinitionWidget(
-                        wordDefinition: word,
-                      )),
+                      ...widget.sentence.words
+                          .map((word) => WordDefinitionWidget(
+                                wordDefinition: word,
+                              )),
                     ],
                   ),
                 ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -20,7 +20,9 @@ class SettingsScreen extends StatelessWidget {
           return ListView(
             padding: const EdgeInsets.all(16.0),
             children: [
-              _buildLanguageSection(context, provider),
+              _buildNativeLanguageSection(context, provider),
+              const SizedBox(height: 24),
+              _buildLearningLanguageSection(context, provider),
               const SizedBox(height: 24),
               _buildCategoriesSection(context, provider),
               const SizedBox(height: 24),
@@ -28,6 +30,144 @@ class SettingsScreen extends StatelessWidget {
             ],
           );
         },
+      ),
+    );
+  }
+
+  Widget _buildNativeLanguageSection(
+      BuildContext context, AppProvider provider) {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.home,
+                  color: Colors.purple.shade600,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Native Language (Translations)',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.purple.shade600,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8.0,
+              children: Language.values.map((language) {
+                final isSelected = provider.nativeLanguage == language;
+                return FilterChip(
+                  label: Text(language.displayName),
+                  selected: isSelected,
+                  onSelected: (selected) {
+                    if (selected) {
+                      provider.setNativeLanguage(language);
+                    }
+                  },
+                  selectedColor: Colors.purple.shade100,
+                  checkmarkColor: Colors.purple.shade600,
+                );
+              }).toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLearningLanguageSection(
+      BuildContext context, AppProvider provider) {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.school,
+                  color: Colors.blue.shade600,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Learning Language',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.blue.shade600,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8.0,
+              children: Language.values.map((language) {
+                final isSelected = provider.selectedLanguage == language;
+                return FilterChip(
+                  label: Text(language.displayName),
+                  selected: isSelected,
+                  onSelected: (selected) {
+                    if (selected) {
+                      provider.setSelectedLanguage(language);
+                    }
+                  },
+                  selectedColor: Colors.blue.shade100,
+                  checkmarkColor: Colors.blue.shade600,
+                );
+              }).toList(),
+            ),
+            if (provider.selectedLanguage.isChinese) ...[
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.blue.shade50,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.blue.shade200),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(Icons.info_outline,
+                            size: 20, color: Colors.blue.shade600),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Chinese Conversion Available',
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            color: Colors.blue.shade600,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'You can view sentences in both Simplified and Traditional Chinese, and convert between them.',
+                      style: TextStyle(
+                        color: Colors.blue.shade700,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }
@@ -115,12 +255,14 @@ class SettingsScreen extends StatelessWidget {
             Wrap(
               spacing: 8.0,
               children: InterestCategory.values.map((category) {
-                final isSelected = provider.selectedCategories.contains(category);
+                final isSelected =
+                    provider.selectedCategories.contains(category);
                 return FilterChip(
                   label: Text(category.getLocalizedName('en')),
                   selected: isSelected,
                   onSelected: (selected) {
-                    final newCategories = List<InterestCategory>.from(provider.selectedCategories);
+                    final newCategories = List<InterestCategory>.from(
+                        provider.selectedCategories);
                     if (selected) {
                       newCategories.add(category);
                     } else {
@@ -175,7 +317,8 @@ class SettingsScreen extends StatelessWidget {
                   child: GestureDetector(
                     onTap: () => _selectTime(context, provider),
                     child: Container(
-                      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 12, horizontal: 16),
                       decoration: BoxDecoration(
                         border: Border.all(color: Colors.grey),
                         borderRadius: BorderRadius.circular(8),

--- a/lib/services/chinese_translation_service.dart
+++ b/lib/services/chinese_translation_service.dart
@@ -1,0 +1,76 @@
+class ChineseTranslationService {
+  // 簡体字から繁体字への基本的な変換マッピング
+  static const Map<String, String> _simplifiedToTraditional = {
+    // 一般的な変換例
+    '学习': '學習',
+    '机器': '機器',
+    '处理': '處理',
+    '数据': '數據',
+    '计算机': '計算機',
+    '网络': '網絡',
+    '电脑': '電腦',
+    '软件': '軟件',
+    '硬件': '硬件',
+    '程序': '程序',
+    '系统': '系統',
+    '技术': '技術',
+    '开发': '開發',
+    '应用': '應用',
+    '服务': '服務',
+    '问题': '問題',
+    '解决': '解決',
+    '方案': '方案',
+    '创新': '創新',
+    '发展': '發展',
+    '改变': '改變',
+    '提供': '提供',
+    '企业': '企業',
+    '灵活': '靈活',
+    '云计算': '雲計算',
+    '人工智能': '人工智慧',
+    '大数据': '大數據',
+    '物联网': '物聯網',
+  };
+
+  // 繁体字から簡体字への変換マッピング（上記の逆）
+  static final Map<String, String> _traditionalToSimplified =
+      _simplifiedToTraditional.map((key, value) => MapEntry(value, key));
+
+  /// 簡体字を繁体字に変換
+  static String convertToTraditional(String simplifiedText) {
+    String result = simplifiedText;
+
+    _simplifiedToTraditional.forEach((simplified, traditional) {
+      result = result.replaceAll(simplified, traditional);
+    });
+
+    return result;
+  }
+
+  /// 繁体字を簡体字に変換
+  static String convertToSimplified(String traditionalText) {
+    String result = traditionalText;
+
+    _traditionalToSimplified.forEach((traditional, simplified) {
+      result = result.replaceAll(traditional, simplified);
+    });
+
+    return result;
+  }
+
+  /// 中国語のバリエーション（簡体字・繁体字）を取得
+  static Map<String, String> getChineseVariations(
+      String text, bool isSimplified) {
+    if (isSimplified) {
+      return {
+        'simplified': text,
+        'traditional': convertToTraditional(text),
+      };
+    } else {
+      return {
+        'simplified': convertToSimplified(text),
+        'traditional': text,
+      };
+    }
+  }
+}

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -14,7 +14,7 @@ class DatabaseService {
 
   static Future<Database> _initDatabase() async {
     String path = join(await getDatabasesPath(), 'todays_sentence.db');
-    
+
     return await openDatabase(
       path,
       version: 1,
@@ -37,7 +37,7 @@ class DatabaseService {
 
   static Future<void> saveSentenceToHistory(Sentence sentence) async {
     final db = await database;
-    
+
     // Check if sentence already exists
     final existing = await db.query(
       _tableName,
@@ -70,7 +70,7 @@ class DatabaseService {
 
   static Future<List<Sentence>> getHistory({int limit = 50}) async {
     final db = await database;
-    
+
     final List<Map<String, dynamic>> maps = await db.query(
       _tableName,
       orderBy: 'viewedAt DESC',
@@ -97,22 +97,25 @@ class DatabaseService {
 
   static String _encodeWords(List<WordDefinition> words) {
     // Simple JSON-like encoding for words
-    final wordsData = words.map((word) => {
-      'word': word.word,
-      'definition': word.definition,
-      'pronunciation': word.pronunciation ?? '',
-      'examples': word.examples.join('|'),
-    }).toList();
-    
-    return wordsData.map((word) => 
-      '${word['word']}~${word['definition']}~${word['pronunciation']}~${word['examples']}'
-    ).join('###');
+    final wordsData = words
+        .map((word) => {
+              'word': word.word,
+              'definition': word.definition,
+              'pronunciation': word.pronunciation ?? '',
+              'examples': word.examples.join('|'),
+            })
+        .toList();
+
+    return wordsData
+        .map((word) =>
+            '${word['word']}~${word['definition']}~${word['pronunciation']}~${word['examples']}')
+        .join('###');
   }
 
   static List<WordDefinition> _decodeWords(String wordsString) {
     try {
       if (wordsString.isEmpty) return [];
-      
+
       final wordEntries = wordsString.split('###');
       return wordEntries.map((entry) {
         final parts = entry.split('~');

--- a/lib/services/history_service.dart
+++ b/lib/services/history_service.dart
@@ -7,14 +7,15 @@ class HistoryService {
 
   static Future<void> saveSentenceToHistory(Sentence sentence) async {
     final prefs = await SharedPreferences.getInstance();
-    
+
     // Get existing history
     final historyJson = prefs.getString(_historyKey) ?? '[]';
     final List<dynamic> historyList = jsonDecode(historyJson);
-    
+
     // Check if sentence already exists
-    final existingIndex = historyList.indexWhere((item) => item['id'] == sentence.id);
-    
+    final existingIndex =
+        historyList.indexWhere((item) => item['id'] == sentence.id);
+
     final sentenceData = {
       'id': sentence.id,
       'text': sentence.text,
@@ -25,29 +26,29 @@ class HistoryService {
       'createdAt': sentence.createdAt.toIso8601String(),
       'viewedAt': DateTime.now().toIso8601String(),
     };
-    
+
     if (existingIndex >= 0) {
       // Update existing entry
       historyList[existingIndex]['viewedAt'] = DateTime.now().toIso8601String();
     } else {
       // Add new entry
       historyList.insert(0, sentenceData);
-      
+
       // Keep only last 50 entries
       if (historyList.length > 50) {
         historyList.removeRange(50, historyList.length);
       }
     }
-    
+
     await prefs.setString(_historyKey, jsonEncode(historyList));
   }
 
   static Future<List<Sentence>> getHistory({int limit = 50}) async {
     final prefs = await SharedPreferences.getInstance();
     final historyJson = prefs.getString(_historyKey) ?? '[]';
-    
+
     final List<dynamic> historyList = jsonDecode(historyJson);
-    
+
     return historyList.take(limit).map((item) {
       return Sentence(
         id: item['id'],

--- a/lib/services/sentence_service.dart
+++ b/lib/services/sentence_service.dart
@@ -2,14 +2,17 @@ import 'dart:math';
 import '../models/sentence.dart';
 import '../models/language.dart';
 import '../models/interest_category.dart';
+import 'chinese_translation_service.dart';
 
 class SentenceService {
   // 事前定義された文章データベース（実際のAPIの代替）
-  static final Map<String, Map<String, List<Map<String, dynamic>>>> _sentenceDatabase = {
+  static final Map<String, Map<String, List<Map<String, dynamic>>>>
+      _sentenceDatabase = {
     'en': {
       'Technology': [
         {
-          'text': 'Artificial intelligence is transforming how we work and live.',
+          'text':
+              'Artificial intelligence is transforming how we work and live.',
           'translation': '人工知能は、私たちの働き方や生活を変革しています。',
           'words': [
             {
@@ -47,7 +50,8 @@ class SentenceService {
       ],
       'Science': [
         {
-          'text': 'Scientists discovered a new species in the Amazon rainforest.',
+          'text':
+              'Scientists discovered a new species in the Amazon rainforest.',
           'translation': '科学者たちはアマゾンの熱帯雨林で新しい種を発見しました。',
           'words': [
             {
@@ -166,7 +170,8 @@ class SentenceService {
       'Technology': [
         {
           'text': '量子コンピュータは従来の計算能力を大幅に超える可能性があります。',
-          'translation': 'Quantum computers have the potential to greatly exceed conventional computing power.',
+          'translation':
+              'Quantum computers have the potential to greatly exceed conventional computing power.',
           'words': [
             {
               'word': '量子',
@@ -184,7 +189,8 @@ class SentenceService {
         },
         {
           'text': '人工知能の発達により、多くの業界で自動化が進んでいます。',
-          'translation': 'Due to the development of artificial intelligence, automation is advancing in many industries.',
+          'translation':
+              'Due to the development of artificial intelligence, automation is advancing in many industries.',
           'words': [
             {
               'word': '発達',
@@ -204,7 +210,8 @@ class SentenceService {
       'Health': [
         {
           'text': '適度な運動と十分な睡眠は健康維持の基本です。',
-          'translation': 'Moderate exercise and adequate sleep are the basics of maintaining health.',
+          'translation':
+              'Moderate exercise and adequate sleep are the basics of maintaining health.',
           'words': [
             {
               'word': '適度',
@@ -222,11 +229,12 @@ class SentenceService {
         }
       ]
     },
-    'zh': {
+    'zh-cn': {
       'Technology': [
         {
           'text': '机器学习正在改变我们处理数据的方式。',
-          'translation': 'Machine learning is changing the way we process data.',
+          'translation':
+              'Machine learning is changing the way we process data.',
           'words': [
             {
               'word': '机器学习',
@@ -244,7 +252,8 @@ class SentenceService {
         },
         {
           'text': '云计算为企业提供了灵活的解决方案。',
-          'translation': 'Cloud computing provides flexible solutions for businesses.',
+          'translation':
+              'Cloud computing provides flexible solutions for businesses.',
           'words': [
             {
               'word': '灵活',
@@ -259,20 +268,183 @@ class SentenceService {
               'examples': ['技术解决方案', '创新解决方案']
             }
           ]
+        },
+        {
+          'text': '人工智能将改变我们的工作方式。',
+          'translation': 'Artificial intelligence will change the way we work.',
+          'words': [
+            {
+              'word': '人工智能',
+              'definition': '模拟人类智能的计算机系统',
+              'pronunciation': 'réngōng zhìnéng',
+              'examples': ['人工智能技术', '人工智能应用']
+            },
+            {
+              'word': '工作方式',
+              'definition': '完成工作的方法和模式',
+              'pronunciation': 'gōngzuò fāngshì',
+              'examples': ['现代工作方式', '灵活工作方式']
+            }
+          ]
+        }
+      ],
+      'Science': [
+        {
+          'text': '科学家发现了新的基因治疗方法。',
+          'translation': 'Scientists discovered new gene therapy methods.',
+          'words': [
+            {
+              'word': '基因治疗',
+              'definition': '通过基因修改治疗疾病的方法',
+              'pronunciation': 'jīyīn zhìliáo',
+              'examples': ['基因治疗技术', '基因治疗研究']
+            },
+            {
+              'word': '方法',
+              'definition': '达到目标的手段或途径',
+              'pronunciation': 'fāngfǎ',
+              'examples': ['治疗方法', '研究方法']
+            }
+          ]
+        }
+      ],
+      'Health': [
+        {
+          'text': '均衡饮食对身体健康至关重要。',
+          'translation': 'A balanced diet is crucial for physical health.',
+          'words': [
+            {
+              'word': '均衡饮食',
+              'definition': '营养搭配合理的饮食',
+              'pronunciation': 'jūnhéng yǐnshí',
+              'examples': ['保持均衡饮食', '均衡饮食习惯']
+            },
+            {
+              'word': '至关重要',
+              'definition': '极其重要，关键性的',
+              'pronunciation': 'zhìguān zhòngyào',
+              'examples': ['至关重要的决定', '至关重要的作用']
+            }
+          ]
+        }
+      ]
+    },
+    'zh-tw': {
+      'Technology': [
+        {
+          'text': '機器學習正在改變我們處理數據的方式。',
+          'translation':
+              'Machine learning is changing the way we process data.',
+          'words': [
+            {
+              'word': '機器學習',
+              'definition': '讓計算機通過數據學習的技術',
+              'pronunciation': 'jīqì xuéxí',
+              'examples': ['機器學習算法', '機器學習模型']
+            },
+            {
+              'word': '處理',
+              'definition': '對事物進行加工、整理',
+              'pronunciation': 'chǔlǐ',
+              'examples': ['處理數據', '處理問題']
+            }
+          ]
+        },
+        {
+          'text': '雲計算為企業提供了靈活的解決方案。',
+          'translation':
+              'Cloud computing provides flexible solutions for businesses.',
+          'words': [
+            {
+              'word': '靈活',
+              'definition': '能夠適應變化的',
+              'pronunciation': 'línghuó',
+              'examples': ['靈活應對', '靈活安排']
+            },
+            {
+              'word': '解決方案',
+              'definition': '解決問題的辦法',
+              'pronunciation': 'jiějué fāng\'àn',
+              'examples': ['技術解決方案', '創新解決方案']
+            }
+          ]
+        },
+        {
+          'text': '人工智能將改變我們的工作方式。',
+          'translation': 'Artificial intelligence will change the way we work.',
+          'words': [
+            {
+              'word': '人工智能',
+              'definition': '模擬人類智能的計算機系統',
+              'pronunciation': 'réngōng zhìnéng',
+              'examples': ['人工智能技術', '人工智能應用']
+            },
+            {
+              'word': '工作方式',
+              'definition': '完成工作的方法和模式',
+              'pronunciation': 'gōngzuò fāngshì',
+              'examples': ['現代工作方式', '靈活工作方式']
+            }
+          ]
+        }
+      ],
+      'Science': [
+        {
+          'text': '科學家發現了新的基因治療方法。',
+          'translation': 'Scientists discovered new gene therapy methods.',
+          'words': [
+            {
+              'word': '基因治療',
+              'definition': '通過基因修改治療疾病的方法',
+              'pronunciation': 'jīyīn zhìliáo',
+              'examples': ['基因治療技術', '基因治療研究']
+            },
+            {
+              'word': '方法',
+              'definition': '達到目標的手段或途徑',
+              'pronunciation': 'fāngfǎ',
+              'examples': ['治療方法', '研究方法']
+            }
+          ]
+        }
+      ],
+      'Health': [
+        {
+          'text': '均衡飲食對身體健康至關重要。',
+          'translation': 'A balanced diet is crucial for physical health.',
+          'words': [
+            {
+              'word': '均衡飲食',
+              'definition': '營養搭配合理的飲食',
+              'pronunciation': 'jūnhéng yǐnshí',
+              'examples': ['保持均衡飲食', '均衡飲食習慣']
+            },
+            {
+              'word': '至關重要',
+              'definition': '極其重要，關鍵性的',
+              'pronunciation': 'zhìguān zhòngyào',
+              'examples': ['至關重要的決定', '至關重要的作用']
+            }
+          ]
         }
       ]
     },
     'de': {
       'Technology': [
         {
-          'text': 'Die Digitalisierung verändert unsere Arbeitswelt grundlegend.',
-          'translation': 'Digitalization is fundamentally changing our working world.',
+          'text':
+              'Die Digitalisierung verändert unsere Arbeitswelt grundlegend.',
+          'translation':
+              'Digitalization is fundamentally changing our working world.',
           'words': [
             {
               'word': 'Digitalisierung',
               'definition': 'der Prozess der digitalen Umwandlung',
               'pronunciation': '/diɡitaliˈziːʁʊŋ/',
-              'examples': ['die Digitalisierung der Wirtschaft', 'Digitalisierung vorantreiben']
+              'examples': [
+                'die Digitalisierung der Wirtschaft',
+                'Digitalisierung vorantreiben'
+              ]
             },
             {
               'word': 'grundlegend',
@@ -286,7 +458,8 @@ class SentenceService {
       'Science': [
         {
           'text': 'Wissenschaftler erforschen die Geheimnisse des Universums.',
-          'translation': 'Scientists are researching the secrets of the universe.',
+          'translation':
+              'Scientists are researching the secrets of the universe.',
           'words': [
             {
               'word': 'erforschen',
@@ -348,9 +521,12 @@ class SentenceService {
     }
   };
 
-  Future<Sentence> getTodaysSentence(Language language, List<InterestCategory> categories) async {
+  Future<Sentence> getTodaysSentence(
+      Language language, List<InterestCategory> categories,
+      [Language? nativeLanguage]) async {
     final languageCode = language.code;
-    final availableCategories = _sentenceDatabase[languageCode]?.keys.toList() ?? [];
+    final availableCategories =
+        _sentenceDatabase[languageCode]?.keys.toList() ?? [];
 
     // 選択されたカテゴリと利用可能なカテゴリの交集合を取得
     final validCategories = categories
@@ -365,16 +541,28 @@ class SentenceService {
 
     // ランダムにカテゴリと文章を選択
     final random = Random();
-    final selectedCategory = validCategories[random.nextInt(validCategories.length)];
+    final selectedCategory =
+        validCategories[random.nextInt(validCategories.length)];
     final sentences = _sentenceDatabase[languageCode]![selectedCategory]!;
     final selectedSentence = sentences[random.nextInt(sentences.length)];
+
+    // Native languageに基づいて翻訳を取得
+    String translation = selectedSentence['translation'];
+    if (nativeLanguage != null) {
+      translation = _getTranslationForNativeLanguage(
+        selectedSentence['text'],
+        languageCode,
+        selectedCategory,
+        nativeLanguage.code,
+      );
+    }
 
     return Sentence(
       id: '${DateTime.now().millisecondsSinceEpoch}',
       text: selectedSentence['text'],
       language: languageCode,
       category: selectedCategory,
-      translation: selectedSentence['translation'],
+      translation: translation,
       words: (selectedSentence['words'] as List)
           .map((word) => WordDefinition.fromJson(word))
           .toList(),
@@ -382,12 +570,15 @@ class SentenceService {
     );
   }
 
-  Future<Sentence> getRandomSentence(Language language, List<InterestCategory> categories) async {
+  Future<Sentence> getRandomSentence(
+      Language language, List<InterestCategory> categories,
+      [Language? nativeLanguage]) async {
     // Use a different random seed to ensure different sentences
     final random = Random(DateTime.now().millisecondsSinceEpoch);
-    
+
     final languageCode = language.code;
-    final availableCategories = _sentenceDatabase[languageCode]?.keys.toList() ?? [];
+    final availableCategories =
+        _sentenceDatabase[languageCode]?.keys.toList() ?? [];
 
     final validCategories = categories
         .where((cat) => availableCategories.contains(cat.englishName))
@@ -398,20 +589,367 @@ class SentenceService {
       validCategories.add(availableCategories.first);
     }
 
-    final selectedCategory = validCategories[random.nextInt(validCategories.length)];
+    final selectedCategory =
+        validCategories[random.nextInt(validCategories.length)];
     final sentences = _sentenceDatabase[languageCode]![selectedCategory]!;
     final selectedSentence = sentences[random.nextInt(sentences.length)];
+
+    // Native languageに基づいて翻訳を取得
+    String translation = selectedSentence['translation'];
+    if (nativeLanguage != null) {
+      translation = _getTranslationForNativeLanguage(
+        selectedSentence['text'],
+        languageCode,
+        selectedCategory,
+        nativeLanguage.code,
+      );
+    }
 
     return Sentence(
       id: '${DateTime.now().millisecondsSinceEpoch}_${random.nextInt(1000)}',
       text: selectedSentence['text'],
       language: languageCode,
       category: selectedCategory,
-      translation: selectedSentence['translation'],
+      translation: translation,
       words: (selectedSentence['words'] as List)
           .map((word) => WordDefinition.fromJson(word))
           .toList(),
       createdAt: DateTime.now(),
     );
+  }
+
+  /// 中国語の文章の簡体字/繁体字バリエーションを取得
+  Map<String, String> getChineseVariations(Sentence sentence) {
+    if (!sentence.language.startsWith('zh')) {
+      return {'original': sentence.text};
+    }
+
+    final isSimplified = sentence.language == 'zh-cn';
+    return ChineseTranslationService.getChineseVariations(
+        sentence.text, isSimplified);
+  }
+
+  /// Native languageに基づいて適切な翻訳を取得
+  String _getTranslationForNativeLanguage(
+    String originalText,
+    String fromLanguage,
+    String category,
+    String toLanguage,
+  ) {
+    // まず、対象言語のデータベースから同じ意味の文章を探す
+    final targetLanguageData = _sentenceDatabase[toLanguage];
+    if (targetLanguageData == null) {
+      // フォールバック：元の翻訳を返す
+      return _getOriginalTranslation(originalText, fromLanguage, category);
+    }
+
+    // カテゴリが存在するかチェック
+    final targetCategoryData = targetLanguageData[category];
+    if (targetCategoryData == null || targetCategoryData.isEmpty) {
+      return _getOriginalTranslation(originalText, fromLanguage, category);
+    }
+
+    // 簡単なマッピング（実際のアプリではより高度な翻訳システムが必要）
+    // ここでは基本的な翻訳マッピングを提供
+    return _getBasicTranslation(originalText, fromLanguage, toLanguage);
+  }
+
+  /// 元の翻訳を取得するヘルパーメソッド
+  String _getOriginalTranslation(
+      String originalText, String fromLanguage, String category) {
+    final sentences = _sentenceDatabase[fromLanguage]?[category];
+    if (sentences != null) {
+      for (final sentence in sentences) {
+        if (sentence['text'] == originalText) {
+          return sentence['translation'] ?? originalText;
+        }
+      }
+    }
+    return originalText;
+  }
+
+  /// 基本的な翻訳を提供するヘルパーメソッド
+  String _getBasicTranslation(
+      String originalText, String fromLanguage, String toLanguage) {
+    // 各言語ペアの基本的な翻訳マッピング
+    final translationMappings = {
+      // English to other languages
+      'en-ja': {
+        'Artificial intelligence is transforming how we work and live.':
+            '人工知能は、私たちの働き方や生活を変革しています。',
+        'Cloud computing enables access to data from anywhere.':
+            'クラウドコンピューティングにより、どこからでもデータにアクセスできます。',
+        'Scientists discovered a new species in the Amazon rainforest.':
+            '科学者たちはアマゾンの熱帯雨林で新しい種を発見しました。',
+        'The telescope captured images of distant galaxies.':
+            '望遠鏡は遠い銀河の画像を捉えました。',
+        'Regular exercise improves both physical and mental health.':
+            '定期的な運動は身体的・精神的健康の両方を改善します。',
+        'A balanced diet provides essential nutrients for the body.':
+            'バランスの取れた食事は体に必要な栄養素を提供します。',
+        'Exploring new cultures broadens your perspective on life.':
+            '新しい文化を探求することで、人生の視野が広がります。',
+        'Innovation drives sustainable business growth.':
+            'イノベーションは持続可能な事業成長を推進します。',
+      },
+      'en-de': {
+        'Artificial intelligence is transforming how we work and live.':
+            'Künstliche Intelligenz verändert, wie wir arbeiten und leben.',
+        'Cloud computing enables access to data from anywhere.':
+            'Cloud-Computing ermöglicht den Zugang zu Daten von überall.',
+        'Scientists discovered a new species in the Amazon rainforest.':
+            'Wissenschaftler entdeckten eine neue Art im Amazonas-Regenwald.',
+        'The telescope captured images of distant galaxies.':
+            'Das Teleskop erfasste Bilder entfernter Galaxien.',
+        'Regular exercise improves both physical and mental health.':
+            'Regelmäßige Bewegung verbessert sowohl die körperliche als auch die geistige Gesundheit.',
+        'A balanced diet provides essential nutrients for the body.':
+            'Eine ausgewogene Ernährung versorgt den Körper mit wichtigen Nährstoffen.',
+        'Exploring new cultures broadens your perspective on life.':
+            'Das Erkunden neuer Kulturen erweitert die Lebensperspektive.',
+        'Innovation drives sustainable business growth.':
+            'Innovation treibt nachhaltiges Unternehmenswachstum voran.',
+      },
+      'en-zh-tw': {
+        'Artificial intelligence is transforming how we work and live.':
+            '人工智能正在改變我們的工作和生活方式。',
+        'Cloud computing enables access to data from anywhere.':
+            '雲端運算使我們能夠從任何地方存取資料。',
+        'Scientists discovered a new species in the Amazon rainforest.':
+            '科學家在亞馬遜雨林發現了新物種。',
+        'The telescope captured images of distant galaxies.': '望遠鏡捕捉到了遙遠星系的圖像。',
+        'Regular exercise improves both physical and mental health.':
+            '定期運動可以改善身心健康。',
+        'A balanced diet provides essential nutrients for the body.':
+            '均衡飲食為身體提供必需的營養素。',
+        'Exploring new cultures broadens your perspective on life.':
+            '探索新文化能拓展您的人生視野。',
+        'Innovation drives sustainable business growth.': '創新推動可持續的商業成長。',
+      },
+      'en-zh-cn': {
+        'Artificial intelligence is transforming how we work and live.':
+            '人工智能正在改变我们的工作和生活方式。',
+        'Cloud computing enables access to data from anywhere.':
+            '云计算使我们能够从任何地方访问数据。',
+        'Scientists discovered a new species in the Amazon rainforest.':
+            '科学家在亚马逊雨林发现了新物种。',
+        'The telescope captured images of distant galaxies.': '望远镜捕捉到了遥远星系的图像。',
+        'Regular exercise improves both physical and mental health.':
+            '定期运动可以改善身心健康。',
+        'A balanced diet provides essential nutrients for the body.':
+            '均衡饮食为身体提供必需的营养素。',
+        'Exploring new cultures broadens your perspective on life.':
+            '探索新文化能拓展您的人生视野。',
+        'Innovation drives sustainable business growth.': '创新推动可持续的商业增长。',
+      },
+      'en-sv': {
+        'Artificial intelligence is transforming how we work and live.':
+            'Artificiell intelligens förändrar hur vi arbetar och lever.',
+        'Cloud computing enables access to data from anywhere.':
+            'Molntjänster möjliggör tillgång till data från var som helst.',
+        'Scientists discovered a new species in the Amazon rainforest.':
+            'Forskare upptäckte en ny art i Amazonas regnskog.',
+        'The telescope captured images of distant galaxies.':
+            'Teleskopet fångade bilder av avlägsna galaxer.',
+        'Regular exercise improves both physical and mental health.':
+            'Regelbunden träning förbättrar både fysisk och mental hälsa.',
+        'A balanced diet provides essential nutrients for the body.':
+            'En balanserad kost ger kroppen viktiga näringsämnen.',
+        'Exploring new cultures broadens your perspective on life.':
+            'Att utforska nya kulturer vidgar ditt perspektiv på livet.',
+        'Innovation drives sustainable business growth.':
+            'Innovation driver hållbar affärstillväxt.',
+      },
+      // German to other languages
+      'de-ja': {
+        'Die Digitalisierung verändert unsere Arbeitswelt grundlegend.':
+            'デジタル化は私たちの労働環境を根本的に変えています。',
+        'Wissenschaftler erforschen die Geheimnisse des Universums.':
+            '科学者たちは宇宙の秘密を探求しています。',
+      },
+      'de-en': {
+        'Die Digitalisierung verändert unsere Arbeitswelt grundlegend.':
+            'Digitalization is fundamentally changing our working world.',
+        'Wissenschaftler erforschen die Geheimnisse des Universums.':
+            'Scientists are researching the secrets of the universe.',
+      },
+      'de-zh-tw': {
+        'Die Digitalisierung verändert unsere Arbeitswelt grundlegend.':
+            '數位化正在從根本上改變我們的工作環境。',
+        'Wissenschaftler erforschen die Geheimnisse des Universums.':
+            '科學家正在探索宇宙的奧秘。',
+      },
+      'de-zh-cn': {
+        'Die Digitalisierung verändert unsere Arbeitswelt grundlegend.':
+            '数字化正在从根本上改变我们的工作环境。',
+        'Wissenschaftler erforschen die Geheimnisse des Universums.':
+            '科学家正在探索宇宙的奥秘。',
+      },
+      'de-sv': {
+        'Die Digitalisierung verändert unsere Arbeitswelt grundlegend.':
+            'Digitaliseringen förändrar vår arbetsmiljö grundläggande.',
+        'Wissenschaftler erforschen die Geheimnisse des Universums.':
+            'Forskare utforskar universums hemligheter.',
+      },
+      // Japanese to other languages
+      'ja-en': {
+        '量子コンピュータは従来の計算能力を大幅に超える可能性があります。':
+            'Quantum computers have the potential to greatly exceed conventional computing power.',
+        '人工知能の発達により、多くの業界で自動化が進んでいます。':
+            'Due to the development of artificial intelligence, automation is advancing in many industries.',
+        '適度な運動と十分な睡眠は健康維持の基本です。':
+            'Moderate exercise and adequate sleep are the basics of maintaining health.',
+      },
+      'ja-de': {
+        '量子コンピュータは従来の計算能力を大幅に超える可能性があります。':
+            'Quantencomputer haben das Potenzial, die herkömmliche Rechenleistung erheblich zu übertreffen.',
+        '人工知能の発達により、多くの業界で自動化が進んでいます。':
+            'Aufgrund der Entwicklung der künstlichen Intelligenz schreitet die Automatisierung in vielen Branchen voran.',
+        '適度な運動と十分な睡眠は健康維持の基本です。':
+            'Mäßige Bewegung und ausreichend Schlaf sind die Grundlagen der Gesunderhaltung.',
+      },
+      'ja-zh-tw': {
+        '量子コンピュータは従来の計算能力を大幅に超える可能性があります。': '量子電腦有可能大幅超越傳統的計算能力。',
+        '人工知能の発達により、多くの業界で自動化が進んでいます。': '隨著人工智能的發展，許多行業的自動化正在推進。',
+        '適度な運動と十分な睡眠は健康維持の基本です。': '適度運動和充足睡眠是維持健康的基礎。',
+      },
+      'ja-zh-cn': {
+        '量子コンピュータは従来の計算能力を大幅に超える可能性があります。': '量子计算机有可能大幅超越传统的计算能力。',
+        '人工知能の発達により、多くの業界で自動化が進んでいます。': '随着人工智能的发展，许多行业的自动化正在推进。',
+        '適度な運動と十分な睡眠は健康維持の基本です。': '适度运动和充足睡眠是维持健康的基础。',
+      },
+      'ja-sv': {
+        '量子コンピュータは従来の計算能力を大幅に超える可能性があります。':
+            'Kvantdatorer har potential att kraftigt överträffa konventionell datorkraft.',
+        '人工知能の発達により、多くの業界で自動化が進んでいます。':
+            'På grund av utvecklingen av artificiell intelligens framskrider automatiseringen i många branscher.',
+        '適度な運動と十分な睡眠は健康維持の基本です。':
+            'Måttlig motion och tillräcklig sömn är grunden för att upprätthålla hälsan.',
+      },
+      // Chinese Simplified to other languages
+      'zh-cn-ja': {
+        '机器学习正在改变我们处理数据的方式。': '機械学習はデータ処理の方法を変えています。',
+        '云计算为企业提供了灵活的解决方案。': 'クラウドコンピューティングは企業に柔軟なソリューションを提供します。',
+        '人工智能将改变我们的工作方式。': '人工知能は私たちの働き方を変えるでしょう。',
+        '科学家发现了新的基因治疗方法。': '科学者は新しい遺伝子治療方法を発見しました。',
+        '均衡饮食对身体健康至关重要。': 'バランスの取れた食事は身体の健康にとって極めて重要です。',
+      },
+      'zh-cn-en': {
+        '机器学习正在改变我们处理数据的方式。':
+            'Machine learning is changing the way we process data.',
+        '云计算为企业提供了灵活的解决方案。':
+            'Cloud computing provides flexible solutions for businesses.',
+        '人工智能将改变我们的工作方式。':
+            'Artificial intelligence will change the way we work.',
+        '科学家发现了新的基因治疗方法。': 'Scientists discovered new gene therapy methods.',
+        '均衡饮食对身体健康至关重要。': 'A balanced diet is crucial for physical health.',
+      },
+      'zh-cn-de': {
+        '机器学习正在改变我们处理数据的方式。':
+            'Maschinelles Lernen verändert die Art, wie wir Daten verarbeiten.',
+        '云计算为企业提供了灵活的解决方案。':
+            'Cloud-Computing bietet Unternehmen flexible Lösungen.',
+        '人工智能将改变我们的工作方式。':
+            'Künstliche Intelligenz wird unsere Arbeitsweise verändern.',
+        '科学家发现了新的基因治疗方法。':
+            'Wissenschaftler entdeckten neue Gentherapie-Methoden.',
+        '均衡饮食对身体健康至关重要。':
+            'Eine ausgewogene Ernährung ist für die körperliche Gesundheit von entscheidender Bedeutung.',
+      },
+      'zh-cn-sv': {
+        '机器学习正在改变我们处理数据的方式。':
+            'Maskininlärning förändrar sättet vi behandlar data.',
+        '云计算为企业提供了灵活的解决方案。': 'Molntjänster ger företag flexibla lösningar.',
+        '人工智能将改变我们的工作方式。':
+            'Artificiell intelligens kommer att förändra vårt arbetssätt.',
+        '科学家发现了新的基因治疗方法。': 'Forskare upptäckte nya genbehandlingsmetoder.',
+        '均衡饮食对身体健康至关重要。': 'En balanserad kost är avgörande för fysisk hälsa.',
+      },
+      'zh-cn-zh-tw': {
+        '机器学习正在改变我们处理数据的方式。': '機器學習正在改變我們處理數據的方式。',
+        '云计算为企业提供了灵活的解决方案。': '雲計算為企業提供了靈活的解決方案。',
+        '人工智能将改变我们的工作方式。': '人工智能將改變我們的工作方式。',
+        '科学家发现了新的基因治疗方法。': '科學家發現了新的基因治療方法。',
+        '均衡饮食对身体健康至关重要。': '均衡飲食對身體健康至關重要。',
+      },
+      // Chinese Traditional to other languages
+      'zh-tw-ja': {
+        '機器學習正在改變我們處理數據的方式。': '機械学習はデータ処理の方法を変えています。',
+        '雲計算為企業提供了靈活的解決方案。': 'クラウドコンピューティングは企業に柔軟なソリューションを提供します。',
+        '人工智能將改變我們的工作方式。': '人工知能は私たちの働き方を変えるでしょう。',
+        '科學家發現了新的基因治療方法。': '科学者は新しい遺伝子治療方法を発見しました。',
+        '均衡飲食對身體健康至關重要。': 'バランスの取れた食事は身体の健康にとって極めて重要です。',
+      },
+      'zh-tw-en': {
+        '機器學習正在改變我們處理數據的方式。':
+            'Machine learning is changing the way we process data.',
+        '雲計算為企業提供了靈活的解決方案。':
+            'Cloud computing provides flexible solutions for businesses.',
+        '人工智能將改變我們的工作方式。':
+            'Artificial intelligence will change the way we work.',
+        '科學家發現了新的基因治療方法。': 'Scientists discovered new gene therapy methods.',
+        '均衡飲食對身體健康至關重要。': 'A balanced diet is crucial for physical health.',
+      },
+      'zh-tw-de': {
+        '機器學習正在改變我們處理數據的方式。':
+            'Maschinelles Lernen verändert die Art, wie wir Daten verarbeiten.',
+        '雲計算為企業提供了靈活的解決方案。':
+            'Cloud-Computing bietet Unternehmen flexible Lösungen.',
+        '人工智能將改變我們的工作方式。':
+            'Künstliche Intelligenz wird unsere Arbeitsweise verändern.',
+        '科學家發現了新的基因治療方法。':
+            'Wissenschaftler entdeckten neue Gentherapie-Methoden.',
+        '均衡飲食對身體健康至關重要。':
+            'Eine ausgewogene Ernährung ist für die körperliche Gesundheit von entscheidender Bedeutung.',
+      },
+      'zh-tw-sv': {
+        '機器學習正在改變我們處理數據的方式。':
+            'Maskininlärning förändrar sättet vi behandlar data.',
+        '雲計算為企業提供了靈活的解決方案。': 'Molntjänster ger företag flexibla lösningar.',
+        '人工智能將改變我們的工作方式。':
+            'Artificiell intelligens kommer att förändra vårt arbetssätt.',
+        '科學家發現了新的基因治療方法。': 'Forskare upptäckte nya genbehandlingsmetoder.',
+        '均衡飲食對身體健康至關重要。': 'En balanserad kost är avgörande för fysisk hälsa.',
+      },
+      'zh-tw-zh-cn': {
+        '機器學習正在改變我們處理數據的方式。': '机器学习正在改变我们处理数据的方式。',
+        '雲計算為企業提供了靈活的解決方案。': '云计算为企业提供了灵活的解决方案。',
+        '人工智能將改變我們的工作方式。': '人工智能将改变我们的工作方式。',
+        '科學家發現了新的基因治療方法。': '科学家发现了新的基因治疗方法。',
+        '均衡飲食對身體健康至關重要。': '均衡饮食对身体健康至关重要。',
+      },
+      // Swedish to other languages
+      'sv-ja': {
+        'Artificiell intelligens kommer att förändra framtiden.':
+            '人工知能は未来を変えるでしょう。',
+        'Forskare studerar klimatförändringar globalt.':
+            '研究者は地球規模で気候変動を研究しています。',
+      },
+      'sv-en': {
+        'Artificiell intelligens kommer att förändra framtiden.':
+            'Artificial intelligence will change the future.',
+        'Forskare studerar klimatförändringar globalt.':
+            'Researchers are studying climate change globally.',
+      },
+      'sv-de': {
+        'Artificiell intelligens kommer att förändra framtiden.':
+            'Künstliche Intelligenz wird die Zukunft verändern.',
+        'Forskare studerar klimatförändringar globalt.':
+            'Forscher untersuchen den Klimawandel global.',
+      },
+      'sv-zh-tw': {
+        'Artificiell intelligens kommer att förändra framtiden.': '人工智能將改變未來。',
+        'Forskare studerar klimatförändringar globalt.': '研究人員正在全球研究氣候變遷。',
+      },
+      'sv-zh-cn': {
+        'Artificiell intelligens kommer att förändra framtiden.': '人工智能将改变未来。',
+        'Forskare studerar klimatförändringar globalt.': '研究人员正在全球研究气候变化。',
+      },
+    };
+
+    final mappingKey = '$fromLanguage-$toLanguage';
+    final mapping = translationMappings[mappingKey];
+
+    return mapping?[originalText] ?? originalText;
   }
 }

--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -11,17 +11,17 @@ class TextToSpeechService {
     await _flutterTts.setVolume(0.8);
     await _flutterTts.setSpeechRate(0.5);
     await _flutterTts.setPitch(1.0);
-    
+
     _isInitialized = true;
   }
 
   static Future<void> speak(String text, Language language) async {
     await initialize();
-    
+
     // Set language for TTS
     String ttsLanguage = _getLanguageCode(language);
     await _flutterTts.setLanguage(ttsLanguage);
-    
+
     await _flutterTts.speak(text);
   }
 
@@ -41,8 +41,10 @@ class TextToSpeechService {
         return 'ja-JP';
       case Language.english:
         return 'en-US';
-      case Language.chinese:
+      case Language.chineseSimplified:
         return 'zh-CN';
+      case Language.chineseTraditional:
+        return 'zh-TW';
       case Language.german:
         return 'de-DE';
       case Language.swedish:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,10 +52,10 @@ dependencies:
 
   # JSON handling
   json_annotation: ^4.8.1
-  
+
   # Text-to-speech
   flutter_tts: ^4.0.2
-  
+
   # SQLite database for history
   sqflite: ^2.3.2
   path: ^1.9.0


### PR DESCRIPTION
TODO:
- READMEを用意
- 選択した言語（母国語、学習中言語）同士がTOPにうまく出ていなかったので修正
- 履歴が見れるように修正
- 音声が聞けるように修正

（やりたい：短文のバリエーションとか、流暢な音声、中文は拼音表示、カテゴリのチューニングなど）